### PR TITLE
Replace MDToolbar with custom header and add explanatory comments

### DIFF
--- a/main.py
+++ b/main.py
@@ -10,7 +10,6 @@ from kivymd.uix.textfield import MDTextField
 from kivymd.uix.menu import MDDropdownMenu
 from kivymd.uix.list import OneLineListItem
 from kivymd.uix.chip import MDChip
-from kivymd.uix.toolbar import MDToolbar
 from kivy.uix.scrollview import ScrollView
 from kivy.uix.widget import Widget
 from kivy.metrics import dp
@@ -21,18 +20,48 @@ from kivymd.toast import toast
 # 日本語フォント設定
 LabelBase.register(DEFAULT_FONT, r'resource\\theme\\font\\mgenplus-1c-regular.ttf')
 
+
+def build_header(title, back_callback=None):
+    """アプリ画面上部のヘッダーを生成する補助関数."""
+
+    # ヘッダー全体の横並びレイアウトを作成
+    header = MDBoxLayout(
+        orientation="horizontal",
+        size_hint_y=None,
+        height=dp(56),
+        padding=(dp(8), dp(8), dp(8), dp(8)),
+        spacing=dp(8),
+    )
+
+    # 戻るボタンが必要な場合は先頭に設置
+    if back_callback is not None:
+        back_button = MDFlatButton(text="戻る", on_press=lambda *_: back_callback())
+        back_button.size_hint_x = None
+        header.add_widget(back_button)
+
+    # 画面タイトルを中央に配置
+    header_label = MDLabel(text=title, font_style="H6", halign="center")
+    header_label.size_hint_x = 1
+    header.add_widget(header_label)
+
+    # タイトルを中央に寄せるための余白ウィジェットを末尾に追加
+    header.add_widget(Widget())
+
+    return header
+
 class MenuScreen(MDScreen):
     """アプリケーションの初期画面."""
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        # 画面全体の配置を縦方向に整えるルートレイアウト
         root_layout = MDBoxLayout(orientation="vertical", spacing=0)
 
-        toolbar = MDToolbar(title="デュエルパフォーマンスログ")
-        toolbar.elevation = 10
-        root_layout.add_widget(toolbar)
+        # ヘッダーを追加し、アプリ名を常に表示
+        root_layout.add_widget(build_header("デュエルパフォーマンスログ"))
 
+        # メインコンテンツはスクロール可能にし、長い情報でも表示が崩れないようにする
         scroll_view = ScrollView()
         content = MDBoxLayout(
             orientation="vertical",
@@ -42,6 +71,7 @@ class MenuScreen(MDScreen):
         )
         content.bind(minimum_height=content.setter("height"))
 
+        # ヒーローカードとナビゲーション項目を順番に追加
         content.add_widget(self._build_hero_card())
         content.add_widget(self._build_navigation_grid())
 
@@ -60,6 +90,7 @@ class MenuScreen(MDScreen):
         self.add_widget(root_layout)
 
     def _build_hero_card(self):
+        # アプリ紹介を行うカードレイアウト
         card = MDCard(
             orientation="vertical",
             padding=(dp(24), dp(24), dp(24), dp(24)),
@@ -88,6 +119,7 @@ class MenuScreen(MDScreen):
             )
         )
 
+        # メインアクションボタンを並べる行
         actions = MDBoxLayout(spacing=dp(12), size_hint_y=None, height=dp(48))
         actions.add_widget(
             MDRaisedButton(
@@ -108,6 +140,7 @@ class MenuScreen(MDScreen):
         return card
 
     def _build_navigation_grid(self):
+        # 主要機能へ移動するためのカード一覧を作成
         grid = MDGridLayout(
             cols=1,
             spacing=dp(16),
@@ -159,6 +192,7 @@ class MenuScreen(MDScreen):
         return grid
 
     def _create_menu_option(self, icon, title, description, screen_name):
+        # メニューカード一枚分のレイアウトを生成
         card = MDCard(
             orientation="vertical",
             padding=(dp(20), dp(20), dp(20), dp(20)),
@@ -168,6 +202,7 @@ class MenuScreen(MDScreen):
             elevation=2,
         )
 
+        # アイコンとタイトルを横並びで配置
         header = MDBoxLayout(spacing=dp(12), size_hint_y=None, height=dp(36))
         header.add_widget(MDIcon(icon=icon, size_hint=(None, None), size=(dp(36), dp(36))))
         header.add_widget(
@@ -179,6 +214,7 @@ class MenuScreen(MDScreen):
         )
         card.add_widget(header)
 
+        # 説明文を本文として追加
         card.add_widget(
             MDLabel(
                 text=description,
@@ -186,6 +222,7 @@ class MenuScreen(MDScreen):
             )
         )
 
+        # 詳細画面へ遷移するボタン行
         button_row = MDBoxLayout(size_hint_y=None, height=dp(48), padding=(0, dp(12), 0, 0))
         button_row.add_widget(Widget())
         button_row.add_widget(
@@ -199,11 +236,13 @@ class MenuScreen(MDScreen):
         return card
 
     def change_screen(self, screen_name):
+        # メニュー内から他画面へ遷移するヘルパー
         if self.manager:
             self.manager.current = screen_name
 
 class BaseManagedScreen(MDScreen):
     def change_screen(self, screen_name):
+        # 指定された画面名へ遷移する共通処理
         if self.manager:
             self.manager.current = screen_name
 
@@ -212,6 +251,7 @@ class DeckRegistrationScreen(BaseManagedScreen):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        # 入力欄の準備: デッキ名・説明・登録済み一覧
         self.name_field = MDTextField(
             hint_text="デッキ名",
             helper_text="必須項目です",
@@ -228,7 +268,13 @@ class DeckRegistrationScreen(BaseManagedScreen):
         )
 
         layout = MDBoxLayout(orientation="vertical", spacing=dp(16), padding=dp(24))
-        layout.add_widget(self._build_toolbar("使用デッキ情報登録"))
+
+        # 画面タイトルと戻るボタンを持つヘッダー
+        layout.add_widget(
+            build_header("使用デッキ情報登録", lambda: self.change_screen("menu"))
+        )
+
+        # 入力フォームとアクションボタンを順に配置
         layout.add_widget(self.name_field)
         layout.add_widget(self.description_field)
         layout.add_widget(
@@ -236,17 +282,16 @@ class DeckRegistrationScreen(BaseManagedScreen):
         )
         layout.add_widget(self.deck_list_label)
 
-        back_button = MDFlatButton(text="トップに戻る", on_press=lambda *_: self.change_screen("menu"))
+        # メニュー画面へ戻るためのボタン
+        back_button = MDFlatButton(
+            text="トップに戻る", on_press=lambda *_: self.change_screen("menu")
+        )
         layout.add_widget(back_button)
 
         self.add_widget(layout)
 
-    def _build_toolbar(self, title):
-        toolbar = MDToolbar(title=title)
-        toolbar.left_action_items = [["arrow-left", lambda *_: self.change_screen("menu")]]
-        return toolbar
-
     def register_deck(self):
+        # 入力値を取得し、空欄がないか確認
         name = self.name_field.text.strip()
         description = self.description_field.text.strip()
 
@@ -254,11 +299,13 @@ class DeckRegistrationScreen(BaseManagedScreen):
             toast("デッキ名を入力してください")
             return
 
+        # 既存データとの重複チェック
         app = MDApp.get_running_app()
         if any(deck["name"] == name for deck in app.decks):
             toast("同じ名前のデッキが既に登録されています")
             return
 
+        # 問題がなければデータを追加し、入力欄を初期化
         app.decks.append({"name": name, "description": description})
         toast("デッキを登録しました")
         self.name_field.text = ""
@@ -266,9 +313,11 @@ class DeckRegistrationScreen(BaseManagedScreen):
         self.update_deck_list()
 
     def on_pre_enter(self):
+        # 画面表示前に最新の登録一覧を反映
         self.update_deck_list()
 
     def update_deck_list(self):
+        # アプリ全体のデッキ情報を参照して表示を更新
         app = MDApp.get_running_app()
         if not app.decks:
             self.deck_list_label.text = "登録済みデッキはありません"
@@ -281,23 +330,28 @@ class SeasonRegistrationScreen(BaseManagedScreen):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
+        # シーズン名入力欄を作成
         self.name_field = MDTextField(
             hint_text="シーズン名",
             helper_text="必須項目です",
             helper_text_mode="on_focus",
         )
+        # シーズンの説明文入力欄を作成
         self.description_field = MDTextField(
             hint_text="シーズン説明",
             multiline=True,
             max_text_length=200,
         )
+        # 登録済みシーズンをまとめて表示するラベル
         self.season_list_label = MDLabel(
             text="登録済みシーズンはありません",
             theme_text_color="Hint",
         )
 
         layout = MDBoxLayout(orientation="vertical", spacing=dp(16), padding=dp(24))
-        layout.add_widget(self._build_toolbar("シーズン情報登録"))
+        layout.add_widget(
+            build_header("シーズン情報登録", lambda: self.change_screen("menu"))
+        )
         layout.add_widget(self.name_field)
         layout.add_widget(self.description_field)
         layout.add_widget(
@@ -308,12 +362,8 @@ class SeasonRegistrationScreen(BaseManagedScreen):
 
         self.add_widget(layout)
 
-    def _build_toolbar(self, title):
-        toolbar = MDToolbar(title=title)
-        toolbar.left_action_items = [["arrow-left", lambda *_: self.change_screen("menu")]]
-        return toolbar
-
     def register_season(self):
+        # 入力内容を取得し、必須項目の確認を行う
         name = self.name_field.text.strip()
         description = self.description_field.text.strip()
 
@@ -321,11 +371,13 @@ class SeasonRegistrationScreen(BaseManagedScreen):
             toast("シーズン名を入力してください")
             return
 
+        # 既存シーズンと名前が重ならないかチェック
         app = MDApp.get_running_app()
         if any(season["name"] == name for season in app.seasons):
             toast("同じ名前のシーズンが既に登録されています")
             return
 
+        # 問題がなければ情報を保存し、表示を更新
         app.seasons.append({"name": name, "description": description})
         toast("シーズンを登録しました")
         self.name_field.text = ""
@@ -333,9 +385,11 @@ class SeasonRegistrationScreen(BaseManagedScreen):
         self.update_season_list()
 
     def on_pre_enter(self):
+        # 表示直前に登録リストを最新状態へ
         self.update_season_list()
 
     def update_season_list(self):
+        # 保持しているシーズン情報を整形し、利用者へ提示
         app = MDApp.get_running_app()
         if not app.seasons:
             self.season_list_label.text = "登録済みシーズンはありません"
@@ -350,6 +404,7 @@ class MatchSetupScreen(BaseManagedScreen):
         self.selected_deck = None
         self.deck_menu = None
 
+        # 対戦カウントとデッキ選択の入力部品を用意
         self.match_count_field = MDTextField(
             hint_text="対戦カウント初期値",
             input_filter="int",
@@ -358,7 +413,9 @@ class MatchSetupScreen(BaseManagedScreen):
         self.deck_button = MDRaisedButton(text="使用デッキを選択", on_press=lambda *_: self.open_deck_menu())
 
         layout = MDBoxLayout(orientation="vertical", spacing=dp(16), padding=dp(24))
-        layout.add_widget(self._build_toolbar("対戦データ入力開始"))
+        layout.add_widget(
+            build_header("対戦データ入力開始", lambda: self.change_screen("menu"))
+        )
         layout.add_widget(self.match_count_field)
         layout.add_widget(self.deck_button)
         layout.add_widget(
@@ -368,16 +425,13 @@ class MatchSetupScreen(BaseManagedScreen):
 
         self.add_widget(layout)
 
-    def _build_toolbar(self, title):
-        toolbar = MDToolbar(title=title)
-        toolbar.left_action_items = [["arrow-left", lambda *_: self.change_screen("menu")]]
-        return toolbar
-
     def on_pre_enter(self):
+        # 画面に入るたびに選択状態をリセット
         self.selected_deck = None
         self.deck_button.text = "使用デッキを選択"
 
     def open_deck_menu(self):
+        # 登録済みデッキから選択肢を生成しドロップダウンで表示
         app = MDApp.get_running_app()
         if not app.decks:
             toast("まずはデッキを登録してください")
@@ -393,6 +447,7 @@ class MatchSetupScreen(BaseManagedScreen):
         ]
 
         if self.deck_menu:
+            # 既存のメニューがある場合は閉じてから新しいものを開く
             self.deck_menu.dismiss()
 
         self.deck_menu = MDDropdownMenu(caller=self.deck_button, items=menu_items, width_mult=4)
@@ -409,12 +464,14 @@ class MatchSetupScreen(BaseManagedScreen):
             toast("使用デッキを選択してください")
             return
 
+        # 入力値が整数として妥当かチェック
         try:
             initial_count = int(self.match_count_field.text or 0)
         except ValueError:
             toast("対戦カウントには数字を入力してください")
             return
 
+        # 設定値をアプリ全体の状態として保持
         app = MDApp.get_running_app()
         app.current_match_settings = {
             "count": initial_count,
@@ -442,7 +499,9 @@ class MatchEntryScreen(BaseManagedScreen):
         )
 
         layout = MDBoxLayout(orientation="vertical", spacing=dp(16), padding=dp(24))
-        layout.add_widget(self._build_toolbar("対戦データ入力"))
+        layout.add_widget(
+            build_header("対戦データ入力", lambda: self.change_screen("match_setup"))
+        )
         layout.add_widget(self.status_label)
         layout.add_widget(MDLabel(text="先攻/後攻を選択", theme_text_color="Secondary"))
         layout.add_widget(self._build_chip_row(["先攻", "後攻"], self.set_turn_choice))
@@ -457,17 +516,14 @@ class MatchEntryScreen(BaseManagedScreen):
 
         self.add_widget(layout)
 
-    def _build_toolbar(self, title):
-        toolbar = MDToolbar(title=title)
-        toolbar.left_action_items = [["arrow-left", lambda *_: self.change_screen("match_setup")]]
-        return toolbar
-
     def _build_chip_row(self, options, callback):
+        # チップを横並びで表示する行レイアウトを準備
         row = MDBoxLayout(spacing=dp(12), size_hint_y=None, height=dp(40))
         if callback == self.set_turn_choice:
             self.turn_chips = []
         chips = []
         for option in options:
+            # 各選択肢をトグル可能なチップとして追加
             chip = MDChip(text=option, check=True)
             chip.bind(on_release=lambda chip, value=option: callback(value))
             row.add_widget(chip)
@@ -491,20 +547,24 @@ class MatchEntryScreen(BaseManagedScreen):
         app = MDApp.get_running_app()
         settings = getattr(app, "current_match_settings", None)
         if not settings:
+            # 初期設定がなければ入力を促すメッセージを表示
             self.status_label.text = "開始画面から初期情報を設定してください"
             return
 
+        # 最新の対戦カウントと使用デッキをステータスに反映
         self.status_label.text = (
             f"対戦カウント: {app.current_match_count} / 使用デッキ: {settings['deck_name']}"
         )
         self.reset_inputs()
 
     def set_turn_choice(self, choice):
+        # 選択されたチップのみアクティブ状態にする
         self.turn_choice = choice
         for chip in self.turn_chips:
             chip.active = chip.text == choice
 
     def set_result_choice(self, choice):
+        # 勝敗選択も同様にアクティブ表示を切り替える
         self.result_choice = choice
         for chip in self.result_chips:
             chip.active = chip.text == choice
@@ -516,6 +576,7 @@ class MatchEntryScreen(BaseManagedScreen):
             toast("開始画面で初期情報を設定してください")
             return
 
+        # 必須選択がすべて揃っているか順番に確認
         if not self.turn_choice:
             toast("先攻/後攻を選択してください")
             return
@@ -524,6 +585,7 @@ class MatchEntryScreen(BaseManagedScreen):
             toast("対戦結果を選択してください")
             return
 
+        # 入力内容を一つの辞書にまとめて保存
         record = {
             "match_no": app.current_match_count,
             "deck_name": settings["deck_name"],
@@ -534,6 +596,7 @@ class MatchEntryScreen(BaseManagedScreen):
         }
         app.match_records.append(record)
 
+        # 試合数をカウントアップし、画面表示と入力欄を更新
         app.current_match_count += 1
         self.status_label.text = (
             f"対戦カウント: {app.current_match_count} / 使用デッキ: {settings['deck_name']}"
@@ -542,6 +605,7 @@ class MatchEntryScreen(BaseManagedScreen):
         toast("対戦結果を記録しました")
 
     def reset_inputs(self):
+        # チップ・テキストフィールドを初期状態に戻す
         self.turn_choice = None
         self.result_choice = None
         for chip in self.turn_chips:
@@ -558,18 +622,22 @@ class StatsScreen(BaseManagedScreen):
         self.selected_deck = None
         self.deck_menu = None
 
+        # 統計情報を表示するラベルを初期化
         self.stats_label = MDLabel(
             text="まだ統計を表示できるデータがありません",
             theme_text_color="Secondary",
         )
 
+        # 絞り込みに利用するボタンを準備
         self.filter_button = MDRaisedButton(
             text="使用デッキで絞り込み",
             on_press=lambda *_: self.open_deck_menu(),
         )
 
         layout = MDBoxLayout(orientation="vertical", spacing=dp(16), padding=dp(24))
-        layout.add_widget(self._build_toolbar("対戦結果統計"))
+        layout.add_widget(
+            build_header("対戦結果統計", lambda: self.change_screen("menu"))
+        )
         layout.add_widget(self.filter_button)
         layout.add_widget(
             MDFlatButton(text="絞り込み解除", on_press=lambda *_: self.clear_filter())
@@ -579,15 +647,12 @@ class StatsScreen(BaseManagedScreen):
 
         self.add_widget(layout)
 
-    def _build_toolbar(self, title):
-        toolbar = MDToolbar(title=title)
-        toolbar.left_action_items = [["arrow-left", lambda *_: self.change_screen("menu")]]
-        return toolbar
-
     def on_pre_enter(self):
+        # 画面表示の度に最新の統計を再計算
         self.update_stats()
 
     def open_deck_menu(self):
+        # 登録済みデッキから絞り込み候補を作成
         app = MDApp.get_running_app()
         if not app.decks:
             toast("デッキが登録されていません")
@@ -603,12 +668,14 @@ class StatsScreen(BaseManagedScreen):
         ]
 
         if self.deck_menu:
+            # 古いメニューを閉じてから新しいメニューを開く
             self.deck_menu.dismiss()
 
         self.deck_menu = MDDropdownMenu(caller=self.filter_button, items=menu_items, width_mult=4)
         self.deck_menu.open()
 
     def set_deck_filter(self, name):
+        # 選択されたデッキ名で絞り込み条件を設定
         self.selected_deck = name
         if self.deck_menu:
             self.deck_menu.dismiss()
@@ -616,17 +683,20 @@ class StatsScreen(BaseManagedScreen):
         self.update_stats()
 
     def clear_filter(self):
+        # 条件を解除して全データを対象に戻す
         self.selected_deck = None
         self.filter_button.text = "使用デッキで絞り込み"
         self.update_stats()
 
     def update_stats(self):
+        # 試合記録から統計情報を計算し、表示内容を組み立てる
         app = MDApp.get_running_app()
         records = app.match_records
         if self.selected_deck:
             records = [r for r in records if r["deck_name"] == self.selected_deck]
 
         if not records:
+            # 条件に合致するデータが無い場合のメッセージ
             if self.selected_deck:
                 self.stats_label.text = f"{self.selected_deck} のデータはまだありません"
             else:
@@ -638,6 +708,7 @@ class StatsScreen(BaseManagedScreen):
         losses = total - wins
         win_rate = (wins / total) * 100
 
+        # 集計結果を見やすい文字列にまとめてラベルへ反映
         header = f"絞り込み: {self.selected_deck or 'すべてのデッキ'}"
         self.stats_label.text = (
             f"{header}\n対戦数: {total}\n勝利: {wins}\n敗北: {losses}\n勝率: {win_rate:.1f}%"
@@ -647,16 +718,16 @@ class StatsScreen(BaseManagedScreen):
 class SettingsScreen(BaseManagedScreen):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        # 設定項目を縦方向に並べるレイアウト
         layout = MDBoxLayout(orientation="vertical", spacing=dp(16), padding=dp(24))
-        toolbar = MDToolbar(title="設定")
-        toolbar.left_action_items = [["arrow-left", lambda *_: self.change_screen("menu")]]
-        layout.add_widget(toolbar)
+        layout.add_widget(build_header("設定", lambda: self.change_screen("menu")))
         layout.add_widget(MDLabel(text="アプリケーション設定", theme_text_color="Secondary"))
         layout.add_widget(MDRaisedButton(text="終了", on_press=lambda *_: self.exit_app()))
         layout.add_widget(MDFlatButton(text="トップに戻る", on_press=lambda *_: self.change_screen("menu")))
         self.add_widget(layout)
 
     def exit_app(self):
+        # アプリを終了しウィンドウを閉じる
         MDApp.get_running_app().stop()
         Window.close()
 


### PR DESCRIPTION
## Summary
- replace MDToolbar usages with a reusable `build_header` helper so screens share a stable header without importing the missing widget
- annotate each workflow step with detailed comments to clarify processing for readers

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e151c829c483338ce2912ef01bc4da