### PR TITLE
Fix fallback match settings type annotation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from typing import Any, Optional
 
 from kivymd.app import MDApp
 from kivymd.uix.screenmanager import MDScreenManager
@@ -35,7 +36,7 @@ class _FallbackAppState:
         self.decks = []
         self.seasons = []
         self.match_records = []
-        self.current_match_settings = None
+        self.current_match_settings: Optional[dict[str, Any]] = None
         self.current_match_count = 0
 
 


### PR DESCRIPTION
## Summary
- import typing helpers for the fallback app state
- annotate `current_match_settings` so it can store match settings dictionaries

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e1752657a88333986a5adc42a727b4