### PR TITLE
Persist duel data with SQLite and refine match entry UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 resource/theme/font/mgenplus-1c-regular.ttf
+resource/db/*.sqlite3
+resource/db/*.db

--- a/function/__init__.py
+++ b/function/__init__.py
@@ -1,0 +1,9 @@
+"""Utility helpers used throughout the application."""
+
+from .database import DatabaseManager, DatabaseError, DuplicateEntryError
+
+__all__ = [
+    "DatabaseManager",
+    "DatabaseError",
+    "DuplicateEntryError",
+]

--- a/function/database.py
+++ b/function/database.py
@@ -1,0 +1,300 @@
+"""High-level helper around the SQLite database used by the app.
+
+The application stores user generated data – such as registered decks,
+season notes and detailed match logs – inside a single SQLite file located
+under :mod:`resource/db`.  This module concentrates all access to that file
+so that the rest of the UI can stay focused on presentation logic.
+
+The manager intentionally exposes simple dictionary based structures instead
+of raw SQLite rows.  That keeps the calling code free from persistence
+details while still allowing the UI to display the stored information.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+class DatabaseError(RuntimeError):
+    """Base error that signals an unexpected database failure."""
+
+
+class DuplicateEntryError(DatabaseError):
+    """Raised when a unique constraint prevents inserting a record."""
+
+
+class DatabaseManager:
+    """Utility wrapper around an on-disk SQLite database file.
+
+    Parameters
+    ----------
+    db_path:
+        Optional custom path to the SQLite database file.  When omitted the
+        database is placed inside ``resource/db`` with the default file name
+        ``duel_performance.sqlite3``.
+    """
+
+    def __init__(self, db_path: Optional[Path | str] = None) -> None:
+        base_dir = Path(__file__).resolve().parent.parent / "resource" / "db"
+        if db_path is None:
+            db_path = base_dir / "duel_performance.sqlite3"
+        else:
+            db_path = Path(db_path)
+            if db_path.is_dir():
+                # Allow callers to pass only the directory and rely on the
+                # default file name.
+                db_path = db_path / "duel_performance.sqlite3"
+
+        self._db_path = db_path
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Low level helpers
+    # ------------------------------------------------------------------
+    def _connect(self) -> sqlite3.Connection:
+        """Return a SQLite connection with sensible defaults.
+
+        Each connection enables foreign key constraints and configures the
+        row factory so results can be accessed as dictionaries.
+        """
+
+        connection = sqlite3.connect(self._db_path)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA foreign_keys = ON;")
+        return connection
+
+    # ------------------------------------------------------------------
+    # Database lifecycle helpers
+    # ------------------------------------------------------------------
+    @property
+    def db_path(self) -> Path:
+        """Expose the current database file path for informational purposes."""
+
+        return self._db_path
+
+    def ensure_database(self) -> None:
+        """Create the database file with all tables when it does not exist."""
+
+        if not self._db_path.exists():
+            self.initialize_database()
+
+    def initialize_database(self) -> None:
+        """Re-create the database file from scratch.
+
+        Existing files are removed before the new empty schema is created.  The
+        method is idempotent and can safely be called multiple times.
+        """
+
+        if self._db_path.exists():
+            self._db_path.unlink()
+
+        self._db_path.parent.mkdir(parents=True, exist_ok=True)
+
+        with sqlite3.connect(self._db_path) as connection:
+            cursor = connection.cursor()
+            cursor.execute("PRAGMA foreign_keys = ON;")
+            cursor.executescript(
+                """
+                CREATE TABLE decks (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT DEFAULT ''
+                );
+
+                CREATE TABLE seasons (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    name TEXT NOT NULL UNIQUE,
+                    description TEXT DEFAULT ''
+                );
+
+                CREATE TABLE matches (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    match_no INTEGER NOT NULL,
+                    deck_name TEXT NOT NULL,
+                    turn TEXT NOT NULL,
+                    opponent_deck TEXT,
+                    keywords TEXT,
+                    result TEXT NOT NULL,
+                    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+                );
+                """
+            )
+
+    # ------------------------------------------------------------------
+    # Data retrieval helpers
+    # ------------------------------------------------------------------
+    def fetch_decks(self) -> list[dict[str, str]]:
+        """Return all registered decks sorted by name."""
+
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "SELECT name, description FROM decks ORDER BY name COLLATE NOCASE"
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def fetch_seasons(self) -> list[dict[str, str]]:
+        """Return the stored season definitions sorted by name."""
+
+        with self._connect() as connection:
+            cursor = connection.execute(
+                "SELECT name, description FROM seasons ORDER BY name COLLATE NOCASE"
+            )
+            return [dict(row) for row in cursor.fetchall()]
+
+    def fetch_matches(self, deck_name: Optional[str] = None) -> list[dict[str, object]]:
+        """Return stored match logs.
+
+        Parameters
+        ----------
+        deck_name:
+            When provided, only matches for the specified deck are returned.
+        """
+
+        query = (
+            "SELECT match_no, deck_name, turn, opponent_deck, keywords, result, created_at"
+            " FROM matches"
+        )
+        params: Iterable[object] = ()
+        if deck_name:
+            query += " WHERE deck_name = ?"
+            params = (deck_name,)
+
+        query += " ORDER BY created_at ASC, id ASC"
+
+        with self._connect() as connection:
+            cursor = connection.execute(query, tuple(params))
+            records: list[dict[str, object]] = []
+            for row in cursor.fetchall():
+                # Keywords are stored as JSON for simplicity.
+                keywords_raw = row["keywords"]
+                keywords = json.loads(keywords_raw) if keywords_raw else []
+                record = {
+                    "match_no": row["match_no"],
+                    "deck_name": row["deck_name"],
+                    "turn": row["turn"],
+                    "opponent_deck": row["opponent_deck"] or "",
+                    "keywords": keywords,
+                    "result": row["result"],
+                    "created_at": row["created_at"],
+                }
+                records.append(record)
+            return records
+
+    def fetch_last_match(self, deck_name: Optional[str] = None) -> Optional[dict[str, object]]:
+        """Return the most recently recorded match.
+
+        When *deck_name* is supplied the search is scoped to that deck.
+        """
+
+        query = (
+            "SELECT match_no, deck_name, turn, opponent_deck, keywords, result, created_at"
+            " FROM matches"
+        )
+        params: Iterable[object] = ()
+        if deck_name:
+            query += " WHERE deck_name = ?"
+            params = (deck_name,)
+
+        query += " ORDER BY created_at DESC, id DESC LIMIT 1"
+
+        with self._connect() as connection:
+            cursor = connection.execute(query, tuple(params))
+            row = cursor.fetchone()
+            if row is None:
+                return None
+
+            keywords_raw = row["keywords"]
+            keywords = json.loads(keywords_raw) if keywords_raw else []
+            return {
+                "match_no": row["match_no"],
+                "deck_name": row["deck_name"],
+                "turn": row["turn"],
+                "opponent_deck": row["opponent_deck"] or "",
+                "keywords": keywords,
+                "result": row["result"],
+                "created_at": row["created_at"],
+            }
+
+    def get_next_match_number(self, deck_name: Optional[str] = None) -> int:
+        """Return the next match number for the given deck.
+
+        The helper inspects the latest match entry and adds one to its
+        ``match_no``.  When the database is empty the value ``1`` is returned.
+        """
+
+        last_match = self.fetch_last_match(deck_name)
+        if last_match is None:
+            return 1
+        last_no = last_match.get("match_no")
+        try:
+            return int(last_no) + 1
+        except (TypeError, ValueError):
+            # When the value was stored as text and is not numeric we fall
+            # back to a safe default.
+            return 1
+
+    # ------------------------------------------------------------------
+    # Data mutation helpers
+    # ------------------------------------------------------------------
+    def add_deck(self, name: str, description: str = "") -> None:
+        """Insert a new deck definition."""
+
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    "INSERT INTO decks (name, description) VALUES (?, ?)",
+                    (name, description),
+                )
+        except sqlite3.IntegrityError as exc:  # pragma: no cover - defensive
+            raise DuplicateEntryError(f"Deck '{name}' already exists") from exc
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - defensive
+            raise DatabaseError("Failed to insert deck") from exc
+
+    def add_season(self, name: str, description: str = "") -> None:
+        """Insert a season definition."""
+
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    "INSERT INTO seasons (name, description) VALUES (?, ?)",
+                    (name, description),
+                )
+        except sqlite3.IntegrityError as exc:  # pragma: no cover - defensive
+            raise DuplicateEntryError(f"Season '{name}' already exists") from exc
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - defensive
+            raise DatabaseError("Failed to insert season") from exc
+
+    def record_match(self, record: dict[str, object]) -> None:
+        """Persist a match record.
+
+        ``record`` must at least contain the keys ``match_no``, ``deck_name``,
+        ``turn`` and ``result``.  Optional keys such as ``opponent_deck`` and
+        ``keywords`` are stored when present.
+        """
+
+        keywords = record.get("keywords", [])
+        keywords_json = json.dumps(list(keywords), ensure_ascii=False)
+
+        try:
+            with self._connect() as connection:
+                connection.execute(
+                    """
+                    INSERT INTO matches (
+                        match_no, deck_name, turn, opponent_deck, keywords, result
+                    )
+                    VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        record.get("match_no", 0),
+                        record["deck_name"],
+                        record["turn"],
+                        record.get("opponent_deck", ""),
+                        keywords_json,
+                        record["result"],
+                    ),
+                )
+        except sqlite3.DatabaseError as exc:  # pragma: no cover - defensive
+            raise DatabaseError("Failed to record match") from exc

--- a/function/resources.py
+++ b/function/resources.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 
+# 文字列リソースが格納されているディレクトリを事前に解決しておく。
 _RESOURCE_DIR = Path(__file__).resolve().parent.parent / "resource" / "json"
 
 

--- a/resource/json/strings.json
+++ b/resource/json/strings.json
@@ -15,7 +15,10 @@
     "app_settings": "アプリケーション設定",
     "exit": "終了",
     "version": "バージョン 0.1.0",
-    "required_helper": "必須項目です"
+    "required_helper": "必須項目です",
+    "cancel": "キャンセル",
+    "execute": "実行",
+    "db_error": "データベース操作でエラーが発生しました"
   },
   "menu": {
     "title": "デュエルパフォーマンスログ",
@@ -91,7 +94,15 @@
     "toast_missing_setup": "開始画面で初期情報を設定してください",
     "toast_select_turn": "先攻/後攻を選択してください",
     "toast_select_result": "対戦結果を選択してください",
-    "toast_recorded": "対戦結果を記録しました"
+    "toast_recorded": "対戦結果を記録しました",
+    "clear_button": "入力内容をクリア",
+    "last_record_title": "直前の入力内容",
+    "last_record_empty": "まだ記録はありません",
+    "last_record_template": "対戦{match_no}: {turn} / 結果: {result}\n相手デッキ: {opponent}\nキーワード: {keywords}",
+    "last_record_no_keywords": "なし",
+    "last_record_no_opponent": "未入力",
+    "copy_last_button": "前回の情報を呼び出す",
+    "toast_copied_previous": "前回の情報を入力欄にコピーしました"
   },
   "stats": {
     "header_title": "対戦結果統計",
@@ -104,7 +115,13 @@
     "summary_template": "{header}\\n対戦数: {total}\\n勝利: {wins}\\n敗北: {losses}\\n勝率: {win_rate:.1f}%"
   },
   "settings": {
-    "header_title": "設定"
+    "header_title": "設定",
+    "db_section_title": "データ管理",
+    "db_init_description": "登録済みデータをすべて削除し、新しいデータベースを作成します。",
+    "db_init_button": "データベースを初期化",
+    "db_init_confirm": "データベースを初期化しますか？登録済みのデータは元に戻せません。",
+    "db_init_success": "データベースを初期化しました",
+    "db_init_failure": "データベースの初期化に失敗しました"
   },
   "placeholders": {
     "card_list": "カードリスト機能は現在準備中です。",


### PR DESCRIPTION
## Summary
- add a dedicated `DatabaseManager` for reading, writing, and initializing the SQLite data store
- update registration, statistics, and settings flows to persist through the database and expose a reset action
- refresh the match entry screen with previous-record reuse controls to support rapid consecutive entries

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68e178a27a5c8333afa7f5b293e37e6e