### PR TITLE
Fix match entry window sync and adjust layouts

### DIFF
--- a/resource/theme/json/strings.json
+++ b/resource/theme/json/strings.json
@@ -76,6 +76,7 @@
     "schedule_end_label": "終了: {date} {time}",
     "schedule_ends_in": "終了まであと {days} 日",
     "schedule_finished": "終了済み",
+    "schedule_no_end": "終了日未設定",
     "empty_message": "登録済みシーズンはありません",
     "toast_missing_name": "シーズン名を入力してください",
     "toast_duplicate": "同じ名前のシーズンが既に登録されています",


### PR DESCRIPTION
## Summary
- restore the match entry screen's ability to resize the window based on the selected mode
- rework the settings screen into scrollable cards to prevent content overlap
- simplify the season list cards to only show the season name, remaining time, and delete action with a new string for missing end dates

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68e20afb0d4c8333ad55bc1ecb2c615c