### PR TITLE
Split match screens by mode and adjust broadcast layout

### DIFF
--- a/function/screen/base.py
+++ b/function/screen/base.py
@@ -17,6 +17,18 @@ from function.cmn_app_state import get_app_state
 from function.cmn_resources import get_text
 
 
+def resolve_screen_name(screen_name: str, *, mode: str | None = None) -> str:
+    """Resolve the actual screen name based on the current UI mode."""
+
+    if screen_name in {"match_setup", "match_entry"}:
+        if mode is None:
+            app = get_app_state()
+            mode = getattr(app, "ui_mode", "normal")
+        if mode == "broadcast":
+            return f"{screen_name}_broadcast"
+    return screen_name
+
+
 def build_header(title, back_callback=None, top_callback=None):
     """アプリ画面上部のヘッダーを生成する共通ユーティリティ."""
 
@@ -125,7 +137,9 @@ class BaseManagedScreen(MDScreen):
         """Navigate to the target screen if available."""
 
         if self.manager:
-            self.manager.current = screen_name
+            mode_hint = getattr(self, "screen_mode", None)
+            resolved = resolve_screen_name(screen_name, mode=mode_hint)
+            self.manager.current = resolved
 
     def _sync_window_size(self, mode: str) -> None:
         """Adjust the window size according to the given mode."""
@@ -142,4 +156,4 @@ class BaseManagedScreen(MDScreen):
             Window.size = target_size
 
 
-__all__ = ["BaseManagedScreen", "build_header"]
+__all__ = ["BaseManagedScreen", "build_header", "resolve_screen_name"]

--- a/function/screen/match_setup_screen.py
+++ b/function/screen/match_setup_screen.py
@@ -20,7 +20,10 @@ from .base import BaseManagedScreen
 
 
 class MatchSetupScreen(BaseManagedScreen):
+    screen_mode = "normal"
+
     def __init__(self, **kwargs):
+        self.screen_mode = getattr(self.__class__, "screen_mode", "normal")
         super().__init__(**kwargs)
         self.selected_deck: str | None = None
         self.deck_menu: MDDropdownMenu | None = None
@@ -87,7 +90,7 @@ class MatchSetupScreen(BaseManagedScreen):
         self.deck_button.text = get_text("match_setup.deck_button_default")
 
         app = get_app_state()
-        mode = getattr(app, "ui_mode", "normal")
+        mode = self.screen_mode or getattr(app, "ui_mode", "normal")
         self._apply_mode_layout(mode)
         self._sync_window_size(mode)
 
@@ -249,10 +252,14 @@ class MatchSetupScreen(BaseManagedScreen):
 
     def on_leave(self):
         app = get_app_state()
-        if getattr(app, "ui_mode", "normal") != "broadcast":
+        if self.screen_mode != "broadcast":
             default_size = getattr(app, "default_window_size", None)
             if default_size:
                 Window.size = default_size
 
 
-__all__ = ["MatchSetupScreen"]
+class MatchSetupBroadcastScreen(MatchSetupScreen):
+    screen_mode = "broadcast"
+
+
+__all__ = ["MatchSetupScreen", "MatchSetupBroadcastScreen"]

--- a/function/screen/menu_screen.py
+++ b/function/screen/menu_screen.py
@@ -17,7 +17,7 @@ from kivymd.uix.screen import MDScreen
 from function.cmn_app_state import get_app_state
 from function.cmn_resources import get_text
 
-from .base import build_header
+from .base import build_header, resolve_screen_name
 
 
 class MenuScreen(MDScreen):
@@ -222,7 +222,8 @@ class MenuScreen(MDScreen):
 
     def change_screen(self, screen_name):
         if self.manager:
-            self.manager.current = screen_name
+            resolved = resolve_screen_name(screen_name)
+            self.manager.current = resolved
 
 
 __all__ = ["MenuScreen"]

--- a/main.py
+++ b/main.py
@@ -17,8 +17,14 @@ from function.cmn_config import load_config
 from function.cmn_logger import log_db_error
 from function.cmn_resources import get_text
 from function.screen.deck_registration_screen import DeckRegistrationScreen
-from function.screen.match_entry_screen import MatchEntryScreen
-from function.screen.match_setup_screen import MatchSetupScreen
+from function.screen.match_entry_screen import (
+    MatchEntryBroadcastScreen,
+    MatchEntryScreen,
+)
+from function.screen.match_setup_screen import (
+    MatchSetupBroadcastScreen,
+    MatchSetupScreen,
+)
 from function.screen.menu_screen import MenuScreen
 from function.screen.season_list_screen import SeasonListScreen
 from function.screen.season_registration_screen import SeasonRegistrationScreen
@@ -91,7 +97,13 @@ class DeckAnalyzerApp(MDApp):
         screen_manager.add_widget(SeasonListScreen(name="season_list"))
         screen_manager.add_widget(SeasonRegistrationScreen(name="season_register"))
         screen_manager.add_widget(MatchSetupScreen(name="match_setup"))
+        screen_manager.add_widget(
+            MatchSetupBroadcastScreen(name="match_setup_broadcast")
+        )
         screen_manager.add_widget(MatchEntryScreen(name="match_entry"))
+        screen_manager.add_widget(
+            MatchEntryBroadcastScreen(name="match_entry_broadcast")
+        )
         screen_manager.add_widget(StatsScreen(name="stats"))
         screen_manager.add_widget(SettingsScreen(name="settings"))
         return screen_manager


### PR DESCRIPTION
## Summary
- add a shared resolver so navigation targets the broadcast-specific screens when the mode requires it
- register dedicated broadcast variants of the match setup and entry screens and update them to manage their own window sizing
- tweak the broadcast match entry layout to hide the match info banner and group all action buttons in one column

## Testing
- python -m compileall function/screen

------
https://chatgpt.com/codex/tasks/task_e_68e4ab2dfa0083338b4766b81d4a601d