### PR TITLE
Add Japanese input/output docstrings

### DIFF
--- a/function/__init__.py
+++ b/function/__init__.py
@@ -1,10 +1,13 @@
-"""Utility helpers exposed at the package level."""
+"""function パッケージで共通利用されるヘルパー群。
 
-# NOTE: `function` パッケージ外から頻繁に利用されるヘルパーを再エクスポート
-# しています。`from function import DatabaseManager` のように短く書けるため、
-# 画面ロジックからの import をシンプルに保てます。
+このモジュールは、アプリ全体で頻繁に利用するクラスや関数を再エクスポートします。
+画面ロジックなどから ``from function import DatabaseManager`` のように簡潔に
+インポートできるようにすることが目的です。
 
-"""Convenience exports for commonly used helpers."""
+戻り値
+    モジュール読み込み時に副作用として ``__all__`` が設定され、公開 API が
+    整理されます。
+"""
 
 from .cmn_database import DatabaseManager, DatabaseError, DuplicateEntryError
 from .cmn_app_state import get_app_state

--- a/function/cmn_app_state.py
+++ b/function/cmn_app_state.py
@@ -1,4 +1,9 @@
-"""Application state helpers shared across screens."""
+"""画面間で共有するアプリケーション状態ユーティリティ。
+
+このモジュールは Kivy/KivyMD の ``MDApp`` インスタンスが取得できない状況
+（ユニットテストなど）でも、画面ロジックから共通状態へ安全にアクセスするための
+フォールバックを提供します。
+"""
 
 # NOTE: Kivy では `MDApp.get_running_app()` を通してアプリ全体の状態へアクセス
 # しますが、テストや一部のモジュールではアプリがまだ起動していない場合も
@@ -18,9 +23,28 @@ from .cmn_database import DatabaseManager
 
 
 class _FallbackAppState:
-    """Provide default attributes when no running MDApp is available."""
+    """稼働中の ``MDApp`` が存在しない場合に利用する擬似状態オブジェクト。
+
+    説明
+        Kivy/KivyMD の画面クラスから共通的に参照される属性群を保持します。
+        実アプリケーションの状態が存在しない場合でも、既定値を返すことで
+        例外を発生させずに処理を継続できます。
+    入力
+        生成時に特別な引数はありません。
+    出力
+        インスタンスは ``theme_cls`` や ``decks`` などの属性を保持し、
+        それらを通じて状態を提供します。
+    """
 
     def __init__(self) -> None:
+        """インスタンス生成時に既定属性を作成します。
+
+        入力
+            追加の引数はありません。
+        出力
+            ``None`` を返します。副作用として ``theme_cls`` の擬似オブジェクトと
+            各種リスト属性を初期化します。
+        """
         # `theme_cls` など KivyMD で一般的に参照される属性を SimpleNamespace で
         # 疑似的に用意しておく。これにより、画面クラスはアプリが未起動でも
         # 例外を出さずに参照を行える。
@@ -28,6 +52,14 @@ class _FallbackAppState:
         self.reset()
 
     def reset(self) -> None:
+        """擬似状態を初期化し、各属性を既定値に戻します。
+
+        入力
+            追加の引数は取りません。内部状態のみを更新します。
+        出力
+            返り値は ``None`` で、副作用として ``config`` や ``decks`` などの
+            属性がリセットされます。
+        """
         # 初期状態をまとめてリセットする。辞書やリストは都度新しいインスタンスを
         # 作成し、外部からの変更が内部状態に影響しないようにしている。
         self.config = load_config()
@@ -47,7 +79,14 @@ _fallback_app_state = _FallbackAppState()
 
 
 def get_app_state():
-    """Return the running app instance or a fallback with default attributes."""
+    """稼働中の ``MDApp`` を返し、存在しない場合はフォールバックを返します。
+
+    入力
+        引数はありません。
+    出力
+        ``MDApp`` が起動中であればそのインスタンス、未起動の場合は
+        :class:`_FallbackAppState` インスタンスを返します。
+    """
 
     # MDApp が起動済みならそのインスタンスを返し、そうでなければフォールバックを返す。
     app = MDApp.get_running_app()
@@ -57,7 +96,14 @@ def get_app_state():
 
 
 def get_fallback_state() -> _FallbackAppState:
-    """Expose the fallback state for modules that need direct access."""
+    """フォールバック状態そのものを直接取得します。
+
+    入力
+        引数はありません。
+    出力
+        :class:`_FallbackAppState` インスタンスを返します。テストコードなどが
+        擬似状態へ直接アクセスしたい場合に利用してください。
+    """
 
     # 直接フォールバック状態を扱いたい（テストなど）場面のために公開。
     return _fallback_app_state

--- a/function/cmn_config.py
+++ b/function/cmn_config.py
@@ -1,4 +1,8 @@
-"""Application configuration management utilities."""
+"""アプリケーション設定ファイルを扱うユーティリティ群。
+
+``resource/theme/config.conf`` に保存された設定を読み込み、辞書形式で返却する
+ヘルパーをまとめています。設定が存在しない場合は、既定値を含む辞書を返します。
+"""
 
 # NOTE: 設定ファイル（`resource/theme/config.conf`）を読み込み、辞書形式で
 # 返すためのヘルパーをまとめています。設定が存在しない場合でも安全に
@@ -23,7 +27,14 @@ DEFAULT_CONFIG: dict[str, Any] = {
 
 
 def load_config() -> dict[str, Any]:
-    """Return the persisted configuration or the defaults when missing."""
+    """設定ファイルを読み込み、辞書に変換して返します。
+
+    入力
+        引数はありません。
+    出力
+        ``dict[str, Any]``
+            ファイルに保存された設定を既定値 ``DEFAULT_CONFIG`` とマージした辞書。
+    """
 
     # `ConfigParser` で INI 形式の設定を読み込む。ファイルがなければ空のまま。
     parser = configparser.ConfigParser()
@@ -38,7 +49,15 @@ def load_config() -> dict[str, Any]:
 
 
 def _configparser_to_dict(parser: configparser.ConfigParser) -> dict[str, Any]:
-    """ConfigParser オブジェクトをネストした辞書へ変換する。"""
+    """``ConfigParser`` オブジェクトをネストした辞書へ変換します。
+
+    入力
+        parser: ``configparser.ConfigParser``
+            INI 形式の設定を保持したパーサー。
+    出力
+        ``dict[str, Any]``
+            セクションをキー、各キー/値をネストした辞書として持つ Python 辞書。
+    """
 
     data: dict[str, Any] = {}
     for section in parser.sections():
@@ -50,7 +69,17 @@ def _configparser_to_dict(parser: configparser.ConfigParser) -> dict[str, Any]:
 
 
 def _deep_update(base: MutableMapping[str, Any], updates: MutableMapping[str, Any]) -> None:
-    """ネストした辞書同士を再帰的にマージする小さなユーティリティ。"""
+    """ネストした辞書同士を再帰的にマージします。
+
+    入力
+        base: ``MutableMapping[str, Any]``
+            マージ結果を書き込む側の辞書。呼び出し後に上書きされます。
+        updates: ``MutableMapping[str, Any]``
+            反映したい値を保持する辞書。``base`` と同じ階層構造を想定します。
+    出力
+        ``None``
+            返り値はありません。副作用として ``base`` が更新されます。
+    """
 
     for key, value in updates.items():
         if (
@@ -64,7 +93,14 @@ def _deep_update(base: MutableMapping[str, Any], updates: MutableMapping[str, An
 
 
 def get_config_path() -> Path:
-    """Expose the configuration path for informational purposes."""
+    """設定ファイルの実体パスを返します。
+
+    入力
+        引数はありません。
+    出力
+        ``Path``
+            ``config.conf`` の絶対パスを表す ``pathlib.Path`` オブジェクト。
+    """
 
     return _CONFIG_PATH
 

--- a/main.py
+++ b/main.py
@@ -53,8 +53,25 @@ if system() == "Windows":
 
 
 class DeckAnalyzerApp(MDApp):
+    """デュエル戦績管理アプリの KivyMD アプリケーションクラス。
+
+    入力
+        インスタンス生成時に特別な引数は必要ありません。
+    出力
+        :class:`MDApp` を継承したアプリケーションとして、画面遷移や DB 管理を
+        司るメソッドを提供します。
+    """
+
     def build(self):
-        """KivyMD アプリ起動時に呼び出される初期化処理。"""
+        """アプリ起動時に UI 構築と初期データ読み込みを行います。
+
+        入力
+            追加の引数はありません。インスタンス属性を初期化します。
+        出力
+            ``MDScreenManager``
+                画面を集約したマネージャを返し、Kivy がルートウィジェットとして
+                使用します。
+        """
 
         # テーマカラーなど、見た目に関する初期設定を行う。
         self.theme_cls.primary_palette = "BlueGray"
@@ -129,7 +146,17 @@ class DeckAnalyzerApp(MDApp):
         return screen_manager
 
     def _handle_version_mismatch(self, current_version: int, expected_version: int) -> str:
-        """DB バージョン不一致時の処理フローをまとめたヘルパー。"""
+        """DB バージョン不一致時の対処処理を実行し、結果メッセージを返します。
+
+        入力
+            current_version: ``int``
+                現在の DB スキーマバージョン。
+            expected_version: ``int``
+                コンフィグで想定される最新バージョン。
+        出力
+            ``str``
+                バックアップや復元処理の結果を画面表示用にまとめた文字列。
+        """
 
         # まず画面へ表示するメッセージ（ログ）を格納するリストを用意する。
         lines = [


### PR DESCRIPTION
## Summary
- update shared utility modules to use日本語docstrings that describeインプットとアウトプット
- document the Kivyアプリのエントリポイント with consistentコメント

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4d2de786c8333b9f68e9b3f4c12c8