### PR TITLE
Fix indentation for dialog buttons definition

### DIFF
--- a/resource/theme/gui/components/Dialogs.kv
+++ b/resource/theme/gui/components/Dialogs.kv
@@ -10,13 +10,10 @@
     auto_dismiss: False
     title: root.title_text
     text: root.message_text
-    buttons: [
-        MDFlatButton(
-            text: root.cancel_text,
+    buttons:
+        MDFlatButton:
+            text: root.cancel_text
             on_release: lambda *_: (root.cancel_callback(), root.dismiss())
-        ),
-        MDRaisedButton(
-            text: root.ok_text,
+        MDRaisedButton:
+            text: root.ok_text
             on_release: lambda *_: (root.ok_callback(), root.dismiss())
-        ),
-    ]


### PR DESCRIPTION
## Summary
- adjust the ConfirmDialog buttons definition to use block-style widget declarations
- resolve the Kivy parser invalid indentation error when loading the KV file

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e682b47cdc833382c75db597ff7264